### PR TITLE
Unlist for as.vector

### DIFF
--- a/R/Comtradrclean_function.R
+++ b/R/Comtradrclean_function.R
@@ -186,11 +186,9 @@ Comtradrclean<-function(DF,YEAR,threshold,cutoff){
   dfFDI<-dfFDI[match(target,dfFDI$iso3),]
 
   GGDP<-as.vector(dfGDP[,2])
-  GGDP<-GGDP$GDP
-  GGDP<-suppressWarnings(lapply(GGDP, as.numeric))
+  GGDP<-suppressWarnings(lapply(GGDP, as.numeric)$GGDP)
   GGDPPC<-as.vector(dfGDPPC[,2])
-  GGDPPC<-GGDPPC$GDPPC
-  GGDPPC<-suppressWarnings(lapply(GGDPPC, as.numeric))
+  GGDPPC<-suppressWarnings(lapply(GGDPPC, as.numeric)$GGDPPC)
   GGDPgrowth<-as.vector(dfGDPgrowth[,2])
   GGDPgrowth<-GGDPgrowth$GDPgrowth
   GGDPgrowth<-suppressWarnings(as.numeric(GGDPgrowth))

--- a/R/Comtradrclean_function.R
+++ b/R/Comtradrclean_function.R
@@ -187,10 +187,10 @@ Comtradrclean<-function(DF,YEAR,threshold,cutoff){
 
   GGDP<-as.vector(dfGDP[,2])
   GGDP<-GGDP$GDP
-  GGDP<-lapply(GGDP, as.numeric)
+  GGDP<-suppressWarnings(lapply(GGDP, as.numeric))
   GGDPPC<-as.vector(dfGDPPC[,2])
   GGDPPC<-GGDPPC$GDPPC
-  GGDPPC<-lapply(GGDPPC, as.numeric)
+  GGDPPC<-suppressWarnings(lapply(GGDPPC, as.numeric))
   GGDPgrowth<-as.vector(dfGDPgrowth[,2])
   GGDPgrowth<-GGDPgrowth$GDPgrowth
   GGDPgrowth<-suppressWarnings(as.numeric(GGDPgrowth))

--- a/R/Comtradrclean_function.R
+++ b/R/Comtradrclean_function.R
@@ -166,12 +166,12 @@ Comtradrclean<-function(DF,YEAR,threshold,cutoff){
   dfREG<-dfREG[match(target,dfREG$COUNTRYlist),]
   #
   RR<-as.vector(dfREG[,2])
-  RR2 <- lapply(RR, as.factor)
+  RR2 <- lapply(RR, as.factor)$REGIONlist
   H<-as.character(dfREG$REGIONlist)
 
   dfINC<-dfINC[match(target,dfINC$COUNTRYlist),]
   KK<-as.vector(dfINC[,2])
-  KK2<-lapply(KK, as.factor)
+  KK2<-lapply(KK, as.factor)$INCOMElist
   U<-as.character(dfINC$INCOMElist)
 
   A<-levels(RR2)

--- a/R/Comtradrclean_function.R
+++ b/R/Comtradrclean_function.R
@@ -166,14 +166,12 @@ Comtradrclean<-function(DF,YEAR,threshold,cutoff){
   dfREG<-dfREG[match(target,dfREG$COUNTRYlist),]
   #
   RR<-as.vector(dfREG[,2])
-  RR2<-dplyr::pull(RR, REGIONlist)
-  RR2<-as.factor(RR)
+  RR2 <- lapply(RR, as.factor)
   H<-as.character(dfREG$REGIONlist)
 
   dfINC<-dfINC[match(target,dfINC$COUNTRYlist),]
   KK<-as.vector(dfINC[,2])
-  KK2<- dplyr::pull(KK,INCOMElist)
-  KK2<-as.factor(KK)
+  KK2<-lapply(KK, as.factor)
   U<-as.character(dfINC$INCOMElist)
 
   A<-levels(RR2)
@@ -189,10 +187,10 @@ Comtradrclean<-function(DF,YEAR,threshold,cutoff){
 
   GGDP<-as.vector(dfGDP[,2])
   GGDP<-GGDP$GDP
-  GGDP<-suppressWarnings(as.numeric(GGDP))
+  GGDP<-lapply(GGDP, as.numeric)
   GGDPPC<-as.vector(dfGDPPC[,2])
   GGDPPC<-GGDPPC$GDPPC
-  GGDPPC<-suppressWarnings(as.numeric(GGDPPC))
+  GGDPPC<-lapply(GGDPPC, as.numeric)
   GGDPgrowth<-as.vector(dfGDPgrowth[,2])
   GGDPgrowth<-GGDPgrowth$GDPgrowth
   GGDPgrowth<-suppressWarnings(as.numeric(GGDPgrowth))

--- a/R/Comtradrclean_function.R
+++ b/R/Comtradrclean_function.R
@@ -165,13 +165,13 @@ Comtradrclean<-function(DF,YEAR,threshold,cutoff){
   target<-CountryNames
   dfREG<-dfREG[match(target,dfREG$COUNTRYlist),]
   #
-  RR<-as.vector(dfREG[,2])
-  RR2 <- lapply(RR, as.factor)$REGIONlist
+  RR<-unlist(dfREG[,2])
+  RR2 <- as.factor(RR)
   H<-as.character(dfREG$REGIONlist)
 
   dfINC<-dfINC[match(target,dfINC$COUNTRYlist),]
-  KK<-as.vector(dfINC[,2])
-  KK2<-lapply(KK, as.factor)$INCOMElist
+  KK<-unlist(dfINC[,2])
+  KK2<-as.factor(KK)
   U<-as.character(dfINC$INCOMElist)
 
   A<-levels(RR2)
@@ -186,9 +186,9 @@ Comtradrclean<-function(DF,YEAR,threshold,cutoff){
   dfFDI<-dfFDI[match(target,dfFDI$iso3),]
 
   GGDP<-unlist(dfGDP[,2])
-  GGDP<-as.numeric(GGDP)
+  GGDP<-suppressWarnings(as.numeric(GGDP))
   GGDPPC<-unlist(dfGDPPC[,2])
-  GGDPPC<-as.numeric(GGDPPC)
+  GGDPPC<-suppressWarnings(as.numeric(GGDPPC))
   GGDPgrowth<-as.vector(dfGDPgrowth[,2])
   GGDPgrowth<-GGDPgrowth$GDPgrowth
   GGDPgrowth<-suppressWarnings(as.numeric(GGDPgrowth))

--- a/R/Comtradrclean_function.R
+++ b/R/Comtradrclean_function.R
@@ -185,10 +185,10 @@ Comtradrclean<-function(DF,YEAR,threshold,cutoff){
   dfGDPgrowth<-dfGDPgrowth[match(target,dfGDPgrowth$iso3),]
   dfFDI<-dfFDI[match(target,dfFDI$iso3),]
 
-  GGDP<-as.vector(dfGDP[,2])
-  GGDP<-suppressWarnings(lapply(GGDP, as.numeric)$GGDP)
-  GGDPPC<-as.vector(dfGDPPC[,2])
-  GGDPPC<-suppressWarnings(lapply(GGDPPC, as.numeric)$GGDPPC)
+  GGDP<-unlist(dfGDP[,2])
+  GGDP<-as.numeric(GGDP)
+  GGDPPC<-unlist(dfGDPPC[,2])
+  GGDPPC<-as.numeric(GGDPPC)
   GGDPgrowth<-as.vector(dfGDPgrowth[,2])
   GGDPgrowth<-GGDPgrowth$GDPgrowth
   GGDPgrowth<-suppressWarnings(as.numeric(GGDPgrowth))


### PR DESCRIPTION
There appeared to be an issue coercing the GGDP and GGDPPC to numeric using as.vector() instead of unlist(). I think it's working a little better with this change and similar changes to RR2 and KK2. 